### PR TITLE
재료에서 양념에 포함되는 항목 제거 #34

### DIFF
--- a/app.py
+++ b/app.py
@@ -21,11 +21,8 @@ def ingredient_listing():
     union_irdnt = list(set(main_irdnt) | set(sub_irdnt))
 
     sauce_irdnt = list(db.recipe_ingredient.distinct("IRDNT_NM", {"IRDNT_TY_NM": "양념"}))
+    union_irdnt = list(set(union_irdnt) - set(sauce_irdnt))
 
-    # TODO: 부주재료 - 양념, 양념 - 부주재료 하면 추천 레시피 선택지가 좁아짐 => 집합 연산 안하면 부주재료-후추 로 들어있음
-    # main_irdnt = list(set(main_irdnt) - set(sauce_irdnt))  # '주재료'와 '양념'의 차집합
-    # sub_irdnt = list(set(sub_irdnt) - set(sauce_irdnt))  # '부재료'와 '양념'의 차집합
-    # union_irdnt = list(set(main_irdnt) | set(sub_irdnt))  # '주재료'와 부재료'의 합집합
     print(f"total = 주재료+부재료: {len(union_irdnt)}, 양념: {len(sauce_irdnt)}")
 
     # 가나다순 정렬


### PR DESCRIPTION
`재료+부재료`에서 `양념`에 포함된 재료들은 제거했습니다.
기존에 `재료+부재료: 간장, 후추`와 같은 항목들은 보이지 않을 것입니다.

하지만, `양념`에 몇몇 `부,주재료`로 분류되어야 하는 `당근` `파` 등의 데이터가 있어서 이 데이터들도 안보이는데,
선택지를 줄이는 방향으로 간다면 이 방법이 나을 것 같아 수정합니다.

➡️ 현재 재료선택은 @KKHoon210417 님이 `select` 에서 `input text`로 변경 중이시니, 재료 선택 리스트 출력에 대해서는 앞으로 크게 신경 안쓰셔도 됩니다!