### PR TITLE
회원가입 후  로그인 이동 시 발생하는 메시지 제거 #61

### DIFF
--- a/static/js/login.js
+++ b/static/js/login.js
@@ -96,7 +96,7 @@ function signUp() {
                 return;
             } else {
                 alert("회원가입을 축하드립니다!")
-                window.location.replace("/")
+                window.location.replace("/login")
             }
         }
     });


### PR DESCRIPTION
회원가입을 완료한 후에 다시 로그인 입력창이 뜨면서 `alert('로그인 정보가 없습니다.')` 메시지가 뜨는 현상을 제거했습니다.

**원인**
회원가입 완료 후 `window.location.replace('/')`로 작성해놔서, 다시 `'/' API`로 요청하여 토큰 유효성 검사를 하기 때문이었습니다.

**해결방법**
`'/login' API`로 요청하도록 수정했습니다.